### PR TITLE
[TASK] Update constraints to PHP, EXT:static_info_tables and TYPO3

### DIFF
--- a/.github/workflows/StaticAnalysis.yaml
+++ b/.github/workflows/StaticAnalysis.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4' ]
+        php: [ '7.4' ]
     name: PHPstan
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-composer-
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 7.4
           coverage: none
       - run: composer install --no-progress
       - run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.2', '7.3', '7.4' ]
-        typo3: [ '^9.5', '^10.4', 'dev-master' ]
+        php: [ '7.4' ]
+        typo3: [ '^11.5', 'dev-master' ]
 
     name: PHP ${{ matrix.php }}, TYPO3 ${{ matrix.typo3 }} tests
     steps:

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
     "mselbach/static-info-tables-ua": "self.version"
   },
   "require": {
-    "php": ">=7.2",
-    "typo3/cms-core": "^9.5 || ^10.4 || dev-master",
-    "sjbr/static-info-tables": "^6.9"
+    "php": ">=7.4",
+    "typo3/cms-core": "^11.5 || dev-master",
+    "sjbr/static-info-tables": "^11.5"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",
     "squizlabs/php_codesniffer": "^3.5",
-    "nimut/testing-framework": "2.x-dev || 3.x-dev || 4.x-dev || ^5.0",
+    "nimut/testing-framework": "^6.0",
     "phpstan/extension-installer": "^1.0",
     "phpstan/phpstan": "^0.12.67",
     "phpstan/phpstan-deprecation-rules": "^0.12.5",


### PR DESCRIPTION
With this change the dependencies are updated and also the tests are
adapted accordingly. Like EXT:static_info_tables with this version only one
TYPO3 version is supported.